### PR TITLE
Add support for endless intervals

### DIFF
--- a/src/CAIDA/BGPStreamWeb/DataBrokerBundle/Interval/Interval.php
+++ b/src/CAIDA/BGPStreamWeb/DataBrokerBundle/Interval/Interval.php
@@ -6,6 +6,8 @@ use JsonSerializable;
 
 class Interval implements JsonSerializable {
 
+    const FOREVER = 0;
+
     private $start;
     private $end;
 
@@ -28,7 +30,7 @@ class Interval implements JsonSerializable {
             throw new \InvalidArgumentException('Invalid Interval: ' . $start . ',' . $end);
         }
 
-        if ($start > $end) {
+        if ($end != Interval::FOREVER && $start > $end) {
             throw new \InvalidArgumentException('Invalid Interval: ' . $start . ',' . $end);
         }
 
@@ -80,11 +82,13 @@ class Interval implements JsonSerializable {
             // they are identical
             return true;
         }
-        if ($interval->getStart() >= $this->getEnd()) {
+        if ($this->getEnd() != Interval::FOREVER &&
+            $interval->getStart() >= $this->getEnd()) {
             return false;
         }
 
-        if ($interval->getEnd() > $this->getEnd()) {
+        if ($this->getEnd() != Interval::FOREVER &&
+            $interval->getEnd() > $this->getEnd()) {
             $this->setEnd($interval->getEnd());
         }
 

--- a/src/CAIDA/BGPStreamWeb/DataBrokerBundle/Interval/IntervalSet.php
+++ b/src/CAIDA/BGPStreamWeb/DataBrokerBundle/Interval/IntervalSet.php
@@ -48,7 +48,8 @@ class IntervalSet implements JsonSerializable {
     public function addInterval($interval)
     {
         $toAdd = true;
-        if ($this->combineOverlapping) {
+        if ($this->combineOverlapping &&
+            $interval->getEnd() != Interval::FOREVER) {
             // check if any of the existing intervals overlap
             foreach ($this->getIntervals() as $exInt) {
                 if ($exInt->getStart() > $interval->getEnd()) {
@@ -94,7 +95,9 @@ class IntervalSet implements JsonSerializable {
     public function getIntervalOverlapping($time)
     {
         foreach ($this->getIntervals() as $interval) {
-            if ($interval->getStart() <= $time && $interval->getEnd() >= $time) {
+            if ($interval->getStart() <= $time &&
+                ($interval->getEnd() == Interval::FOREVER ||
+                 $interval->getEnd() >= $time)) {
                 return $interval;
             }
         }
@@ -147,7 +150,8 @@ class IntervalSet implements JsonSerializable {
             }
 
             if(!$this->lastInterval ||
-               $interval->getEnd() >= $this->lastInterval->getEnd()) {
+               ($interval->getEnd() == Interval::FOREVER ||
+                $interval->getEnd() >= $this->lastInterval->getEnd())) {
                 $this->lastInterval = $interval;
             }
         }

--- a/src/CAIDA/BGPStreamWeb/DataBrokerBundle/Repository/BgpDataRepository.php
+++ b/src/CAIDA/BGPStreamWeb/DataBrokerBundle/Repository/BgpDataRepository.php
@@ -45,9 +45,13 @@ class BgpDataRepository extends EntityRepository {
         $parameters['w'.$p1] =
             $applyOffset ? $interval->getStart() - static::START_OFFSET :
                 $interval->getStart();
-        $parameters['w'.$p2] = $interval->getEnd();
+        if ($interval->getEnd() != Interval::FOREVER) {
+            $parameters['w' . $p2] = $interval->getEnd();
 
-        return '(d.fileTime >= :w' . $p1 . ' AND d.fileTime <= :w' . $p2 . ')';
+            return '(d.fileTime >= :w' . $p1 . ' AND d.fileTime <= :w' . $p2 . ')';
+        } else {
+            return '(d.fileTime >= :w' . $p1 . ')';
+        }
     }
 
     /**
@@ -70,6 +74,7 @@ class BgpDataRepository extends EntityRepository {
         // if we've already tried to get data and the end of the constraint
         // interval is after the end of the last interval in the set, return null
         if($retryCnt > 0 &&
+           $intervals->getLastInterval()->getEnd() != Interval::FOREVER &&
            $minInitialTime + $constraintLength >
            $intervals->getLastInterval()->getEnd()
         ) {


### PR DESCRIPTION
When the end of an interval is set to `0` (`BGPSTREAM_FOREVER`), the interval will be considered to have no end.
