### PR TITLE
Fix stupid bug that prevented no-data seek to fail

### DIFF
--- a/src/CAIDA/BGPStreamWeb/DataBrokerBundle/Repository/BgpDataRepository.php
+++ b/src/CAIDA/BGPStreamWeb/DataBrokerBundle/Repository/BgpDataRepository.php
@@ -233,7 +233,7 @@ class BgpDataRepository extends EntityRepository {
             }
 
             // compute constraint interval length based on number of retries
-            $constraintLength = $retries+1 *
+            $constraintLength = ($retries+1) *
                                 min(static::QUERY_WINDOW_MAX,
                                     static::QUERY_WINDOW * pow(2, $retries));
 


### PR DESCRIPTION
When querying for a time interval that began with no data, this bug would cause the broker to increase the constraint window by 1 second at a time, causing a huge number of queries to be issued to the database, and the app would time out before finding any data.
