### PR TITLE
Another fudge tweak

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -109,8 +109,8 @@ fos_http_cache:
                     overwrite: true
                     cache_control:
                         public: true
-                        max_age: 19
-                        s_maxage: 19
+                        max_age: 10
+                        s_maxage: 10
                     last_modified: "-1 hour"
                     vary: [Accept-Encoding]
 

--- a/src/CAIDA/BGPStreamWeb/DataBrokerBundle/Controller/DefaultController.php
+++ b/src/CAIDA/BGPStreamWeb/DataBrokerBundle/Controller/DefaultController.php
@@ -20,7 +20,7 @@ class DefaultController extends Controller
     const MAX_INTERVALS = 100;
 
     // the amount to round the response time by (used to facilitate caching)
-    const RESPONSE_TS_GRANULARITY = 19;
+    const RESPONSE_TS_GRANULARITY = 10;
 
     private $cacheParams;
 


### PR DESCRIPTION
This seems to give the desired performance with caida-bmp, but it is the most risky as it opens up the backend much more (10s cache instead of 120s). Fingers crossed!
