### PR TITLE
Update wandio installation guide

### DIFF
--- a/src/CAIDA/BGPStreamWeb/HomepageBundle/Resources/views/Default/docs/install/bgpstream.html.twig
+++ b/src/CAIDA/BGPStreamWeb/HomepageBundle/Resources/views/Default/docs/install/bgpstream.html.twig
@@ -50,7 +50,7 @@ $ ./configure
 $ make
 # make install</code></pre>
 
-        <p><strong>Note:</strong> download timeout failures could happen if using earlier versions of wandio  (<1.0.5)</p>
+        <p><strong>Note:</strong> download timeout failures could happen if using earlier versions of wandio  (&lt;1.0.5)</p>
 
         <p><strong>Note:</strong> Ensure that the last lines from <code>configure</code>
             show a <em>Yes</em> result for at least <i>zlib</i>, <i>bz2</i>, and <i>libcurl</i>
@@ -149,7 +149,7 @@ $ sudo make install clean</code></pre>
         <pre><code>$ cd /usr/ports/devel/wandio
 $ sudo make install clean</code></pre>
 
-        <p><strong>Note:</strong> download timeout failures could happen if using earlier versions of wandio  (<1.0.5)</p>
+        <p><strong>Note:</strong> download timeout failures could happen if using earlier versions of wandio  (&lt;1.0.5)</p>
 
         {#
         <p><em>or</em></p>
@@ -251,7 +251,7 @@ $ make
 $ sudo make install
 $ sudo ldconfig</code></pre>
 
-        <p><strong>Note:</strong> download timeout failures could happen if using earlier versions of wandio  (<1.0.5)</p>
+        <p><strong>Note:</strong> download timeout failures could happen if using earlier versions of wandio  (&lt;1.0.5)</p>
 
         <p>See the generic install instructions for details on how to install
             into a non-default location.</p>
@@ -311,7 +311,7 @@ $ make
 $ sudo make install
 $ sudo ldconfig</code></pre>
 
-        <p><strong>Note:</strong> download timeout failures could happen if using earlier versions of wandio  (<1.0.5)</p>
+        <p><strong>Note:</strong> download timeout failures could happen if using earlier versions of wandio  (&lt;1.0.5)</p>
 
         <p>See the generic install instructions for details on how to install
             into a non-default location.</p>
@@ -360,7 +360,7 @@ $ make
 $ sudo make install
 $ sudo ldconfig</code></pre>
 
-        <p><strong>Note:</strong> download timeout failures could happen if using earlier versions of wandio  (<1.0.5)</p>
+        <p><strong>Note:</strong> download timeout failures could happen if using earlier versions of wandio  (&lt;1.0.5)</p>
 
         <p>See the generic install instructions for details on how to install
             into a non-default location.</p>
@@ -420,7 +420,7 @@ $ ./configure
 $ make
 $ sudo make install</code></pre>
 
-        <p><strong>Note:</strong> download timeout failures could happen if using earlier versions of wandio  (<1.0.5)</p>
+        <p><strong>Note:</strong> download timeout failures could happen if using earlier versions of wandio  (&lt;1.0.5)</p>
 
         <p>See the generic install instructions for details on how to install
             into a non-default location.</p>


### PR DESCRIPTION
- Change `wandio` version requirement from `1.0.4` to `4.0.0`.
- Also warns timeout issue if using version below `1.0.5`.