### PR TITLE
Update bgpstream website content for RC3 release

### DIFF
--- a/src/CAIDA/BGPStreamWeb/HomepageBundle/Resources/views/Default/home.html.twig
+++ b/src/CAIDA/BGPStreamWeb/HomepageBundle/Resources/views/Default/home.html.twig
@@ -20,7 +20,7 @@
             <a class="btn btn-lg btn-warning"
                href="{{ path('caida_bgpstream_web_homepage', {'page': 'v2-whats-new'}) }}"
                role="button">
-                BGPStream V2 (RC2) Available Now!
+                BGPStream V2 (RC3) Available Now!
             </a>
         </p>
     </div>

--- a/src/CAIDA/BGPStreamWeb/HomepageBundle/Resources/views/Default/news.html.twig
+++ b/src/CAIDA/BGPStreamWeb/HomepageBundle/Resources/views/Default/news.html.twig
@@ -16,12 +16,28 @@
     <hr>
     <div class="news-item">
         <h2>
+            <a href="/v2-whats-new">BGPStream 2.0.0-RC3 Released</a>
+
+            <small>February 19 2020</small>
+        </h2>
+        <p>
+            This is the third public release candidate of BGPStream V2. Learn more about
+            <a href="/v2-whats-new">what's new in V2</a>.
+        </p>
+        <p>
+            It is available from the
+            <a href="{{ path('caida_bgpstream_web_homepage', {'page': 'download'}) }}">Downloads</a>
+            page.
+        </p>
+    </div>
+    <div class="news-item">
+        <h2>
             <a href="/v2-whats-new">BGPStream 2.0.0-RC2 Released</a>
 
             <small>November 22 2019</small>
         </h2>
         <p>
-            This is the first public release of BGPStream V2. Learn more about
+            This is the second public release candidate of BGPStream V2. Learn more about
             <a href="/v2-whats-new">what's new in V2</a>.
         </p>
         <p>

--- a/src/CAIDA/BGPStreamWeb/HomepageBundle/Resources/views/Default/v2-whats-new.html.twig
+++ b/src/CAIDA/BGPStreamWeb/HomepageBundle/Resources/views/Default/v2-whats-new.html.twig
@@ -36,7 +36,7 @@
                     <a class="btn btn-md btn-success"
                        href="{{ path('caida_bgpstream_web_homepage', {'page': 'download'}) }}"
                        role="button">
-                        Download BGPStream V2 (RC2)
+                        Download BGPStream V2 (RC3)
                     </a>
                 </p>
             </div>


### PR DESCRIPTION
- update all web content referring to RC2 to RC3
- added a news item for RC3 release (also refer RC3 as the third public
  release candidate instead of the second, avoid confusion)